### PR TITLE
Initial implementation of channel-specific reminders

### DIFF
--- a/dasbit/plugin/remind.py
+++ b/dasbit/plugin/remind.py
@@ -18,6 +18,7 @@ class Remind:
 
         self.config[nickname].append({
             'message': message,
+            'channel': message.target,
             'from':    source.prefix['nickname'],
             'time':    time()
         })
@@ -31,7 +32,11 @@ class Remind:
 
         nickname = message.prefix['nickname']
 
-        for reminder in self.config[nickname]:
+        for i, reminder in enumerate(self.config[nickname]):
+            # Do not send the reminder if it was set in a different channel
+            if 'channel' in reminder and message.target != reminder['channel']:
+                continue
+
             # Fallback for old reminders
             if not 'time' in reminder:
                 date = datetime.datetime.utcnow()
@@ -45,5 +50,5 @@ class Remind:
                 )
             )
 
-        del self.config[nickname]
-        self.config.save()
+            del self.config[nickname][i]
+            self.config.save()


### PR DESCRIPTION
This should degrade gracefully for reminders set before channel-specificity was added.

This approach may not always be desirable. For example, a user may set a reminder for someone in a channel they are very rarely active in. In that case, it might be desired that the reminder be sent to the user the first time they are seen in any public channel that the bot is in.

We could alternatively check the flags on the channel that the reminder was set in, but this still leaves the chance for sensitive reminders to be leaked into largely public channels that were set in "less public" channels. E.g., pdog sets a reminder for GeeH in #roave, but Zend\Bot shows him the reminder in #zftalk. Yes, we could explain to everyone that reminders should be set only in the backroom channel so Zend\Bot "knows" it's a private channel, but it still leaves room for accidents.

One other option would be to PM them any reminders that were set in a different channel than the one they become active in.
